### PR TITLE
Contrib/admins support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ config.toml
 
 # fork of their module for personal reasons
 node-teamspeak
+
+# contrib plugins
+plugins/contrib/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ config.toml
 node-teamspeak
 
 # contrib plugins
-plugins/contrib/*.js
+plugins/contrib/*

--- a/config.toml.example
+++ b/config.toml.example
@@ -15,3 +15,8 @@ google = true
 howhot = true
 img = true
 ud = true
+
+# these are uids of admins
+[admins]
+sean = "tIfU8lpVDfj1EnNbRuHmtNp/wX0="
+quibs = "SoHHSfrTKmJOsJ3TKjhuso84rhA="

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,7 @@ pass = "PaSsWoRd"
 
 
 [plugins]
+admin = true
 bing = true
 cid = true
 google = true

--- a/plugins.js
+++ b/plugins.js
@@ -1,5 +1,12 @@
+var fs = require('fs');
+
 function fetchPlugin(name, config) {
-    var plugin = require('./plugins/' + name);
+    var path = "./plugins/" + name;
+    if (!fs.existsSync(path + '.js')) {
+        path = "./plugins/contrib/" + name;
+    }
+
+    var plugin = require(path);
     if (typeof plugin.config == "function") {
         plugin.config(config);
     }

--- a/plugins.js
+++ b/plugins.js
@@ -35,6 +35,14 @@ exports.init = function(config_plugins) {
     return exports;
 }
 
+exports.startPlugins = function(dobby) {
+    plugins.forEach(function(item) {
+        if (typeof item.init == "function") {
+            item.init(dobby);
+        }
+    })
+}
+
 exports.onMessage = function(msg, dobby) {
 	plugins.forEach(function(item) {
 		if (typeof item.onMessage == "function") {

--- a/plugins/admin.js
+++ b/plugins/admin.js
@@ -1,0 +1,38 @@
+// admin tools
+
+var async = require('async');
+
+exports.onMessage = function(msg, dobby) {
+	var terms = msg.split(" ");
+    var command = terms.shift();
+
+    if (command == ".admin") {
+    	dobby.client_from.is_admin(function(err, is_admin) {
+    		if (is_admin) {
+    			dobby.respond("Not finished.");
+    			return;
+
+    			var subcommand = terms.shift();
+
+		    	if (subcommand == "add") {
+		    		dobby.find_clients(terms.join(" "), function(err, clients) {
+		    			if (err) {
+		    				dobby.respond("Couldn't fetch user list for some reason.")
+		    			} else {
+		    				if (clients.length == 1) {
+		    					clients[0].private_message("I'll be adding you to the admin list (not actually lol)");
+		    				} else if (clients.length == 0) {
+		    					dobby.respond("No users match that name.");
+		    				} else {
+		    					dobby.respond("Ambiguous username!");
+		    				}
+		    			}
+		    		})
+		    	}
+    		} else {
+    			dobby.respond("You're not an admin.")
+    			return;
+    		}
+    	})
+    }
+}

--- a/plugins/contrib/README.md
+++ b/plugins/contrib/README.md
@@ -1,0 +1,3 @@
+Plugins that aren't provided by dobby should be placed in this directory.
+
+None of these plugins are placed in the git repo.


### PR DESCRIPTION
- Added `contrib` directory in plugins. Put plugins here you don't want in mainline dobby. The first example of this is [dobby-quibs](https://github.com/FCoQ/dobby-quibs).
- Added support for admins. Admin tools are not finished but the structure is there.

This should get us closer to replacing the old dobby bot.
